### PR TITLE
Improvements to offline-playback.sh

### DIFF
--- a/misc/offline-playback.sh
+++ b/misc/offline-playback.sh
@@ -1,34 +1,47 @@
 #!/bin/bash
 
+#
+# Run as: seiscomp exec offline-playback.sh [mseed-volume] [output-xml]
+#
+
 if [ "$#" -lt 2 ]; then
     echo "Usage: $0 [mseed-volume] [output-xml]"
     exit 0
 fi
 
-SCPATH="/opt/seiscomp3/bin/seiscomp exec"
-DBFLAG="-d mysql://sysop:sysop@localhost/seiscomp3"
+#
+# Optionally use a different database than what is already configured in seiscomp installation
+#
+#DBFLAG="-d mysql://user:password@host/database"
+#DBFLAG="--plugins dbpostgresql -d postgresql://user:password@host/database"
+#DBFLAG="--plugins dbsqlite3 -d sqlite3:///home/sysop/sc3_db.sqlite"
+
 STORAGE=$DBFLAG
-CONFIGFLAGS="--verbosity=4"
+CONFIGFLAGS="--verbosity=4 " #--console=1" 
 FLAGS="$CONFIGFLAGS $STORAGE"
 
 echo "Cleaning database"
-$SCPATH scdbstrip --days 0 $FLAGS
+scdbstrip --days 0 $FLAGS
+
 echo "Starting scanloc..."
-$SCPATH scautoloc --playback  $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
-#$SCPATH scanloc2 $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
+scautoloc --playback  $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
+
+# Optional second pipeline (scautoloc2)
+#scautoloc2 $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
 
 echo "Starting magtool..."
-$SCPATH scmag $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautoloc &
+scmag $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautoloc &
 echo "Starting eventtool..."
-$SCPATH scevent $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scmag &
+scevent $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scmag &
 echo "Starting sceplog..."
-$SCPATH sceplog $CONFIGFLAGS --auto-shutdown=1 --shutdown-master-module=scevent > $2 &
+sceplog $CONFIGFLAGS --auto-shutdown=1 --shutdown-master-module=scevent > $2 &
 pid=$!
-# Start autopick
-#$SCPATH autopick2 $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
+
 echo "Starting autopick..."
-$SCPATH scautopick -I $1 $FLAGS --playback --start-stop-msg=1 
+# Optional second pipeline (scautopick2)
+#scautopick2 $FLAGS --start-stop-msg=1 --auto-shutdown=1 --shutdown-master-module=scautopick &
+scautopick -I $1 $FLAGS --playback --start-stop-msg=1
+
 echo "Finished waveform processing"
 wait $pid
 echo "Finished event processing"
-


### PR DESCRIPTION
Similarly to my other PRs I am suggesting here to run the scritp as:

`/path_to_one_specific_installation/seiscomp exec offline-playback.sh`

Leaving the burden to `seiscomp exec` of managing the environment variables correctly.

Also the DBFLAG is now optional as the default behaviour is to use seiscomp configured database.

