### PR TITLE
Remove SEISCOMP_ROOT and friends from playback.sh

### DIFF
--- a/playback.cfg.template
+++ b/playback.cfg.template
@@ -1,6 +1,3 @@
-# SEISCOMP installtion to use (e.g. "/home/sysop/seiscomp3")
-SEISCOMP_ROOT=""
-
 # URL of the production machine
 HOST=""
 

--- a/playback.sh
+++ b/playback.sh
@@ -24,11 +24,6 @@ function loadsconf(){
     then 
         echo Loading $CONFIGFILE ...
         source "$CONFIGFILE" || (echo Can t load configuration in $CONFIGFILE && exit 1)
-	export SEISCOMP_ROOT=$SEISCOMP_ROOT
-	export LD_LIBRARY_PATH="$SEISCOMP_ROOT/lib:$LD_LIBRARY_PATH"
-	export PYTHONPATH="$SEISCOMP_ROOT/lib/python:$PYTHONPATH"
-	export MANPATH="$SEISCOMP_ROOT/man:$MANPATH"
-	export PATH="$SEISCOMP_ROOT/bin:$PATH"
     fi
 }
 


### PR DESCRIPTION
[This](https://github.com/yannikbehr/sc3-playback/commit/5a3fb02fa573ff922e66a1dd747ed538bfd0675f) commit introduced lots of unnecessary and hard to maintain changes. Many variables are now set and handled in playback.sh: SEISCOMP_ROOT, LD_LIBRARY_PATH, PYTHONPATH, MANPATH, PATH

Running `seiscomp exec playback.sh`  gives the same effect as manually handling all those environment variables, but also this command is transparent and maintainable and also it sets more variables than currently done by playback script. The list of required environment variables might change in the future and using `seiscomp exec` relieves us from keeping track of those changes.

An easy way of running commands with seiscomp environment is to open a shell session like this:

`/path_to_one_specific_installation/seiscomp exec bash`
